### PR TITLE
Add Firebase-driven FAQ page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 // src/App.tsx
-import React, { Suspense, lazy } from 'react';
+import React, { Suspense } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { Layout } from './components/Layout';
 import Login from './pages/Login';
@@ -8,12 +8,10 @@ import { AdminLayout } from './components/AdminLayout';
 import HomePage from './pages/HomePage';
 import Location from './pages/Location';
 import AdminPage from './pages/AdminPage';
+import FaqPage from './pages/FaqPage';
 
 function ContactPage() {
   return <h2>Contact Us</h2>;
-}
-function FAQPage() {
-  return <h2>FAQ</h2>;
 }
 
 export default function App() {
@@ -51,7 +49,7 @@ export default function App() {
           path="/faq"
           element={
             <Layout>
-              <FAQPage />
+              <FaqPage />
             </Layout>
           }
         />

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,6 +1,8 @@
 // src/firebase.ts
 import { initializeApp } from 'firebase/app';
 import { getAuth, GoogleAuthProvider } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+import { getStorage } from 'firebase/storage';
 
 const firebaseConfig = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY!,
@@ -14,3 +16,5 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const googleProvider = new GoogleAuthProvider();
+export const db = getFirestore(app);
+export const storage = getStorage(app);

--- a/src/pages/FaqPage.tsx
+++ b/src/pages/FaqPage.tsx
@@ -1,0 +1,150 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Container,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { ImageUploader } from '../components/ImageUploader';
+import { PodcastUploader } from '../components/PodcastUploader';
+import {
+  collection,
+  getDocs,
+  addDoc,
+  Timestamp,
+  DocumentData,
+} from 'firebase/firestore';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { db, storage, auth } from '../firebase';
+import { useAuthState } from 'react-firebase-hooks/auth';
+
+interface FaqItem {
+  id: string;
+  question: string;
+  answer: string;
+  imageUrl?: string;
+  podcastUrl?: string;
+}
+
+export default function FaqPage() {
+  const [faqs, setFaqs] = useState<FaqItem[]>([]);
+  const [question, setQuestion] = useState('');
+  const [answer, setAnswer] = useState('');
+  const [imageUrl, setImageUrl] = useState<string>();
+  const [podcastUrl, setPodcastUrl] = useState<string>();
+  const [user] = useAuthState(auth);
+
+  useEffect(() => {
+    const fetchFaqs = async () => {
+      const snap = await getDocs(collection(db, 'faqs'));
+      const items: FaqItem[] = snap.docs.map((d) => ({
+        id: d.id,
+        ...(d.data() as DocumentData),
+      })) as FaqItem[];
+      setFaqs(items);
+    };
+    fetchFaqs();
+  }, []);
+
+  const uploadFile = async (file: File, folder: string) => {
+    const storageRef = ref(storage, `${folder}/${Date.now()}_${file.name}`);
+    await uploadBytes(storageRef, file);
+    return await getDownloadURL(storageRef);
+  };
+
+  const handleImageUpload = async (files: File[]) => {
+    if (files.length === 0) return;
+    const url = await uploadFile(files[0], 'faq_images');
+    setImageUrl(url);
+  };
+
+  const handlePodcastUpload = async (files: File[]) => {
+    if (files.length === 0) return;
+    const url = await uploadFile(files[0], 'faq_podcasts');
+    setPodcastUrl(url);
+  };
+
+  const handleAddFaq = async () => {
+    if (!question || !answer) return;
+    const docRef = await addDoc(collection(db, 'faqs'), {
+      question,
+      answer,
+      imageUrl: imageUrl || null,
+      podcastUrl: podcastUrl || null,
+      createdAt: Timestamp.now(),
+    });
+    setFaqs((prev) => [
+      {
+        id: docRef.id,
+        question,
+        answer,
+        imageUrl,
+        podcastUrl,
+      },
+      ...prev,
+    ]);
+    setQuestion('');
+    setAnswer('');
+    setImageUrl(undefined);
+    setPodcastUrl(undefined);
+  };
+
+  return (
+    <Container sx={{ py: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Frequently Asked Questions
+      </Typography>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        {faqs.map((f) => (
+          <Box key={f.id} sx={{ borderBottom: 1, borderColor: 'divider', pb: 2 }}>
+            <Typography variant="h6">{f.question}</Typography>
+            <Typography variant="body2" paragraph>
+              {f.answer}
+            </Typography>
+            {f.imageUrl && (
+              <Box
+                component="img"
+                src={f.imageUrl}
+                alt="FAQ related"
+                sx={{ maxWidth: '100%', mb: 1 }}
+              />
+            )}
+            {f.podcastUrl && (
+              <Box component="audio" controls src={f.podcastUrl} sx={{ width: '100%' }} />
+            )}
+          </Box>
+        ))}
+      </Box>
+
+      {user && (
+        <Box mt={4} sx={{ borderTop: 1, borderColor: 'divider', pt: 3 }}>
+          <Typography variant="h5" gutterBottom>
+            Add FAQ
+          </Typography>
+          <TextField
+            label="Question"
+            fullWidth
+            value={question}
+            onChange={(e) => setQuestion(e.target.value)}
+            sx={{ mb: 2 }}
+          />
+          <TextField
+            label="Answer"
+            fullWidth
+            multiline
+            minRows={3}
+            value={answer}
+            onChange={(e) => setAnswer(e.target.value)}
+            sx={{ mb: 2 }}
+          />
+          <ImageUploader onUpload={handleImageUpload} />
+          <PodcastUploader onUpload={handlePodcastUpload} />
+          <Button variant="contained" onClick={handleAddFaq}>
+            Save FAQ
+          </Button>
+        </Box>
+      )}
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- integrate Firestore and Storage in `firebase.ts`
- create `FaqPage` with image and podcast uploads saved to Firebase
- wire FAQ page into router

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840677d965883219833e51f030d04db