### PR TITLE
Add Firebase-powered admin media and FAQ page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 // src/App.tsx
-import React, { Suspense, lazy } from 'react';
+import React, { Suspense } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { Layout } from './components/Layout';
 import Login from './pages/Login';
@@ -8,12 +8,10 @@ import { AdminLayout } from './components/AdminLayout';
 import HomePage from './pages/HomePage';
 import Location from './pages/Location';
 import AdminPage from './pages/AdminPage';
+import FaqPage from './pages/FaqPage';
 
 function ContactPage() {
   return <h2>Contact Us</h2>;
-}
-function FAQPage() {
-  return <h2>FAQ</h2>;
 }
 
 export default function App() {
@@ -51,7 +49,7 @@ export default function App() {
           path="/faq"
           element={
             <Layout>
-              <FAQPage />
+              <FaqPage />
             </Layout>
           }
         />

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,6 +1,8 @@
 // src/firebase.ts
 import { initializeApp } from 'firebase/app';
 import { getAuth, GoogleAuthProvider } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+import { getStorage } from 'firebase/storage';
 
 const firebaseConfig = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY!,
@@ -14,3 +16,5 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const googleProvider = new GoogleAuthProvider();
+export const db = getFirestore(app);
+export const storage = getStorage(app);

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -16,11 +16,24 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 import { ImageUploader } from '../components/ImageUploader';
 import { PodcastUploader } from '../components/PodcastUploader';
+import {
+  collection,
+  getDocs,
+  addDoc,
+  deleteDoc,
+  doc,
+  updateDoc,
+  Timestamp,
+  DocumentData,
+} from 'firebase/firestore';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { db, storage } from '../firebase';
 
 interface MediaItem {
   id: string;
   name: string;
-  url?: string;
+  url: string;
+  type: 'image' | 'podcast';
 }
 
 export default function AdminPage() {
@@ -28,39 +41,80 @@ export default function AdminPage() {
   const [images, setImages] = useState<MediaItem[]>([]);
   const [podcasts, setPodcasts] = useState<MediaItem[]>([]);
 
-  // Simulate fetching existing uploads
+  // Load existing media from Firestore
   useEffect(() => {
-    // TODO: fetch real data from your backend/storage
-    setImages([]);
-    setPodcasts([]);
+    const fetchMedia = async () => {
+      const snap = await getDocs(collection(db, 'media'));
+      const items: MediaItem[] = snap.docs.map((d) => ({
+        id: d.id,
+        ...(d.data() as DocumentData),
+      })) as MediaItem[];
+      setImages(items.filter((i) => i.type === 'image'));
+      setPodcasts(items.filter((i) => i.type === 'podcast'));
+    };
+    fetchMedia();
   }, []);
 
-  const handleDelete = (id: string, type: 'image' | 'podcast') => {
+  const handleDelete = async (id: string, type: 'image' | 'podcast') => {
+    await deleteDoc(doc(db, 'media', id));
     if (type === 'image') setImages(images.filter((i) => i.id !== id));
     else setPodcasts(podcasts.filter((p) => p.id !== id));
-    // TODO: call API to delete
   };
 
-  const handleReplace = (id: string, file: File, type: 'image' | 'podcast') => {
-    // TODO: upload new file then update state
-    console.log(`Replace ${type} ${id} with`, file);
+  const handleReplace = async (
+    id: string,
+    file: File,
+    type: 'image' | 'podcast'
+  ) => {
+    const url = await uploadFile(
+      file,
+      type === 'image' ? 'uploads/images' : 'uploads/podcasts'
+    );
+    await updateDoc(doc(db, 'media', id), {
+      url,
+      name: file.name,
+      updatedAt: Timestamp.now(),
+    });
+    const updater = (items: MediaItem[]) =>
+      items.map((i) => (i.id === id ? { ...i, url, name: file.name } : i));
+    if (type === 'image') setImages(updater);
+    else setPodcasts(updater);
   };
 
-  const handleImageUpload = (files: File[]) => {
-    // After uploading, add to list
-    const newItems = files.map((f) => ({
-      id: Date.now() + f.name,
-      name: f.name,
-    }));
-    setImages((prev) => [...newItems, ...prev]);
+  const uploadFile = async (file: File, folder: string) => {
+    const storageRef = ref(storage, `${folder}/${Date.now()}_${file.name}`);
+    await uploadBytes(storageRef, file);
+    return await getDownloadURL(storageRef);
   };
 
-  const handlePodcastUpload = (files: File[]) => {
-    const newItems = files.map((f) => ({
-      id: Date.now() + f.name,
-      name: f.name,
-    }));
-    setPodcasts((prev) => [...newItems, ...prev]);
+  const handleImageUpload = async (files: File[]) => {
+    const uploaded: MediaItem[] = [];
+    for (const file of files) {
+      const url = await uploadFile(file, 'uploads/images');
+      const docRef = await addDoc(collection(db, 'media'), {
+        type: 'image',
+        name: file.name,
+        url,
+        createdAt: Timestamp.now(),
+      });
+      uploaded.push({ id: docRef.id, name: file.name, url, type: 'image' });
+    }
+    setImages((prev) => [...uploaded, ...prev]);
+  };
+
+  const handlePodcastUpload = async (files: File[]) => {
+    const uploaded: MediaItem[] = [];
+    for (const file of files) {
+      const url = await uploadFile(file, 'uploads/podcasts');
+      const docRef = await addDoc(collection(db, 'media'), {
+        type: 'podcast',
+        name: file.name,
+        url,
+        createdAt: Timestamp.now(),
+      });
+      uploaded.push({ id: docRef.id, name: file.name, url, type: 'podcast' });
+    }
+    setPodcasts((prev) => [...uploaded, ...prev]);
   };
 
   return (

--- a/src/pages/FaqPage.tsx
+++ b/src/pages/FaqPage.tsx
@@ -1,0 +1,199 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Container,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { ImageUploader } from '../components/ImageUploader';
+import { PodcastUploader } from '../components/PodcastUploader';
+import {
+  collection,
+  getDocs,
+  addDoc,
+  Timestamp,
+  DocumentData,
+} from 'firebase/firestore';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { db, storage, auth } from '../firebase';
+import { useAuthState } from 'react-firebase-hooks/auth';
+
+interface FaqItem {
+  id: string;
+  question: string;
+  answer: string;
+  imageUrl?: string;
+  podcastUrl?: string;
+}
+
+interface MediaItem {
+  id: string;
+  name: string;
+  url: string;
+  type: 'image' | 'podcast';
+}
+
+export default function FaqPage() {
+  const [faqs, setFaqs] = useState<FaqItem[]>([]);
+  const [question, setQuestion] = useState('');
+  const [answer, setAnswer] = useState('');
+  const [imageUrl, setImageUrl] = useState<string>();
+  const [podcastUrl, setPodcastUrl] = useState<string>();
+  const [images, setImages] = useState<MediaItem[]>([]);
+  const [podcasts, setPodcasts] = useState<MediaItem[]>([]);
+  const [user] = useAuthState(auth);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const faqSnap = await getDocs(collection(db, 'faqs'));
+      const faqItems: FaqItem[] = faqSnap.docs.map((d) => ({
+        id: d.id,
+        ...(d.data() as DocumentData),
+      })) as FaqItem[];
+      setFaqs(faqItems);
+
+      const mediaSnap = await getDocs(collection(db, 'media'));
+      const mediaItems: MediaItem[] = mediaSnap.docs.map((d) => ({
+        id: d.id,
+        ...(d.data() as DocumentData),
+      })) as MediaItem[];
+      setImages(mediaItems.filter((m) => m.type === 'image'));
+      setPodcasts(mediaItems.filter((m) => m.type === 'podcast'));
+    };
+    fetchData();
+  }, []);
+
+  const uploadFile = async (file: File, folder: string) => {
+    const storageRef = ref(storage, `${folder}/${Date.now()}_${file.name}`);
+    await uploadBytes(storageRef, file);
+    return await getDownloadURL(storageRef);
+  };
+
+  const handleImageUpload = async (files: File[]) => {
+    if (files.length === 0) return;
+    const url = await uploadFile(files[0], 'faq_images');
+    setImageUrl(url);
+  };
+
+  const handlePodcastUpload = async (files: File[]) => {
+    if (files.length === 0) return;
+    const url = await uploadFile(files[0], 'faq_podcasts');
+    setPodcastUrl(url);
+  };
+
+  const handleAddFaq = async () => {
+    if (!question || !answer) return;
+    const docRef = await addDoc(collection(db, 'faqs'), {
+      question,
+      answer,
+      imageUrl: imageUrl || null,
+      podcastUrl: podcastUrl || null,
+      createdAt: Timestamp.now(),
+    });
+    setFaqs((prev) => [
+      {
+        id: docRef.id,
+        question,
+        answer,
+        imageUrl,
+        podcastUrl,
+      },
+      ...prev,
+    ]);
+    setQuestion('');
+    setAnswer('');
+    setImageUrl(undefined);
+    setPodcastUrl(undefined);
+  };
+
+  return (
+    <Container sx={{ py: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Frequently Asked Questions
+      </Typography>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        {faqs.map((f) => (
+          <Box key={f.id} sx={{ borderBottom: 1, borderColor: 'divider', pb: 2 }}>
+            <Typography variant="h6">{f.question}</Typography>
+            <Typography variant="body2" paragraph>
+              {f.answer}
+            </Typography>
+            {f.imageUrl && (
+              <Box
+                component="img"
+                src={f.imageUrl}
+                alt="FAQ related"
+                sx={{ maxWidth: '100%', mb: 1 }}
+              />
+            )}
+            {f.podcastUrl && (
+              <Box component="audio" controls src={f.podcastUrl} sx={{ width: '100%' }} />
+            )}
+          </Box>
+        ))}
+      </Box>
+
+      {images.length > 0 && (
+        <Box mt={4}>
+          <Typography variant="h5" gutterBottom>
+            Videos
+          </Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+            {images.map((img) => (
+              <Box
+                key={img.id}
+                component="img"
+                src={img.url}
+                alt={img.name}
+                sx={{ maxWidth: 300, width: '100%', borderRadius: 1 }}
+              />
+            ))}
+          </Box>
+        </Box>
+      )}
+
+      {podcasts.length > 0 && (
+        <Box mt={4}>
+          <Typography variant="h5" gutterBottom>
+            Podcasts
+          </Typography>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            {podcasts.map((p) => (
+              <Box key={p.id} component="audio" controls src={p.url} />
+            ))}
+          </Box>
+        </Box>
+      )}
+
+      {user && (
+        <Box mt={4} sx={{ borderTop: 1, borderColor: 'divider', pt: 3 }}>
+          <Typography variant="h5" gutterBottom>
+            Add FAQ
+          </Typography>
+          <TextField
+            label="Question"
+            fullWidth
+            value={question}
+            onChange={(e) => setQuestion(e.target.value)}
+            sx={{ mb: 2 }}
+          />
+          <TextField
+            label="Answer"
+            fullWidth
+            multiline
+            minRows={3}
+            value={answer}
+            onChange={(e) => setAnswer(e.target.value)}
+            sx={{ mb: 2 }}
+          />
+          <ImageUploader onUpload={handleImageUpload} />
+          <PodcastUploader onUpload={handlePodcastUpload} />
+          <Button variant="contained" onClick={handleAddFaq}>
+            Save FAQ
+          </Button>
+        </Box>
+      )}
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- connect admin dashboard to Firestore/Storage for media management
- fetch and render uploaded images and podcasts on FAQ page

## Testing
- `npm test --silent` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6840677d965883219833e51f030d04db